### PR TITLE
Fix demo evaluation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,14 @@ script:
     # Quickly test the generation of bot demos
     - python3 -m scripts.make_agent_demos --env BabyAI-GoToRedBallGrey-v0 --episodes 100 --valid-episodes 32
 
+    # Quickly test the evaluation of bot demos
+    - python3 -m scripts.evaluate --env BabyAI-GoToRedBallGrey-v0 --demos BabyAI-GoToRedBallGrey-v0_agent
+
     # Quick test for imitation learning
-    - python3 -m scripts.train_il --env BabyAI-GoToRedBallGrey-v0 --demos BabyAI-GoToRedBallGrey-v0_agent --val-interval 1 --patience 0 --episodes 100 --val-episodes 50
+    - python3 -m scripts.train_il --env BabyAI-GoToRedBallGrey-v0 --demos BabyAI-GoToRedBallGrey-v0_agent --model GoToRedBallGrey-il --val-interval 1 --patience 0 --episodes 100 --val-episodes 50
+
+    # Quickly test the evaluation of models
+    - python3 -m scripts.evaluate --env BabyAI-GoToRedBallGrey-v0 --model GoToRedBallGrey-il
 
     # Quick test for imitation learning with multi env
     - python3 -m scripts.train_il --multi-env BabyAI-GoToRedBall-v0 BabyAI-GoToRedBallGrey-v0 --multi-demos BabyAI-GoToRedBallGrey-v0_agent BabyAI-GoToRedBallGrey-v0_agent --val-interval 1 --patience 0 --multi-episodes 100 100 --val-episodes 50

--- a/babyai/evaluate.py
+++ b/babyai/evaluate.py
@@ -43,6 +43,17 @@ def evaluate(agent, env, episodes, model_agent=True, offsets=None):
     return logs
 
 
+def evaluate_demo_agent(agent, episodes):
+    logs = {"num_frames_per_episode": [], "return_per_episode": []}
+
+    number_of_demos = len(agent.demos)
+
+    for demo_id in range(min(number_of_demos, episodes)):
+        logs["num_frames_per_episode"].append(len(agent.demos[demo_id]))
+
+    return logs
+
+
 class ManyEnvs(gym.Env):
 
     def __init__(self, envs):

--- a/scripts/evaluate_all_demos.py
+++ b/scripts/evaluate_all_demos.py
@@ -13,13 +13,11 @@ import babyai.utils as utils
 
 folder = os.path.join(utils.storage_dir(), "demos")
 for filename in sorted(os.listdir(folder)):
-    if filename.endswith(".pkl"):
-        env = filename.split("_")[0]
-        demos = filename[:-4]  # Remove the .pkl part of the name
-        if not env.startswith('BabyAI-') and not env.endswith('-v0'):
-            print("> File: {} has to start with the level name (BabyAI-xxx-v0)".format(demos))
-            continue
-        print("> Env: {} - {}".format(env, demos))
-        seed = 0 if demos.endswith('valid') else 1
-        command = ["python evaluate.py --env {} --demos {} --seed {}".format(env, demos, seed)] + sys.argv[1:]
+    if filename.endswith(".pkl") and 'valid' in filename:
+        env = 'BabyAI-BossLevel-v0'  # It doesn't really matter. The evaluation only considers the lengths of demos.
+        demo = filename[:-4]  # Remove the .pkl part of the name
+
+        print("> Demos: {}".format(demo))
+
+        command = ["python evaluate.py --env {} --demos {} --worst-episodes-to-show 0".format(env, demo)] + sys.argv[1:]
         call(" ".join(command), shell=True)


### PR DESCRIPTION
This PR fixes demo evaluation. It was broken before.
It also adds 2 tests in Travis: Evaluate models and demos.

The `evaluate_all_demos` script in this PR can be used to reproduce the second column of Table 2 of the paper.