### PR TITLE
use seeds >= 1e9 for validation, use 1 example per seed in demo

### DIFF
--- a/babyai/arguments.py
+++ b/babyai/arguments.py
@@ -75,8 +75,8 @@ class ArgumentParser(argparse.ArgumentParser):
                             help="image embedding architecture")
 
         # Validation parameters
-        self.add_argument("--val-seed", type=int, default=0,
-                            help="seed for environment used for validation (default: 0)")
+        self.add_argument("--val-seed", type=int, default=1e9,
+                            help="seed for environment used for validation (default: 1e9)")
         self.add_argument("--val-interval", type=int, default=1,
                             help="number of epochs between two validation checks (default: 1)")
         self.add_argument("--val-episodes", type=int, default=500,

--- a/babyai/evaluate.py
+++ b/babyai/evaluate.py
@@ -81,11 +81,8 @@ class ManyEnvs(gym.Env):
 
 
 # Returns the performance of the agent on the environment for a particular number of episodes.
-def batch_evaluate(agent, env_name, seed, episodes, seed_shift=1e9, return_obss_actions=False):
+def batch_evaluate(agent, env_name, seed, episodes, return_obss_actions=False):
     num_envs = min(256, episodes)
-
-    seed += seed_shift
-    seed = int(seed)
 
     envs = []
     for i in range(num_envs):

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -24,8 +24,8 @@ parser.add_argument("--demos", default=None,
                     help="name of the demos file (REQUIRED or --demos-origin or --model REQUIRED)")
 parser.add_argument("--episodes", type=int, default=1000,
                     help="number of episodes of evaluation (default: 1000)")
-parser.add_argument("--seed", type=int, default=None,
-                    help="random seed (default: 0 if model agent, 1 if demo agent) -- needs to be set to 0 if valid")
+parser.add_argument("--seed", type=int, default=1e9,
+                    help="random seed")
 parser.add_argument("--argmax", action="store_true", default=False,
                     help="action with highest probability is selected for model agent")
 parser.add_argument("--contiguous-episodes", action="store_true", default=False,
@@ -63,8 +63,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     assert_text = "ONE of --model or --demos-origin or --demos must be specified."
     assert int(args.model is None) + int(args.demos_origin is None) + int(args.demos is None) == 2, assert_text
-    if args.seed is None:
-        args.seed = 0 if args.model is not None else 1
 
     start_time = time.time()
     logs = main(args, args.seed, args.episodes)


### PR DESCRIPTION
An attempt to refactor the parts of the code that are responsible for seeding and reseting the environment. Implements  #23 .