### PR TITLE
GoNextToSubgoal to replace GoToObj

### DIFF
--- a/babyai/arguments.py
+++ b/babyai/arguments.py
@@ -75,7 +75,7 @@ class ArgumentParser(argparse.ArgumentParser):
                             help="image embedding architecture")
 
         # Validation parameters
-        self.add_argument("--val-seed", type=int, default=1e9,
+        self.add_argument("--val-seed", type=int, default=int(1e9),
                             help="seed for environment used for validation (default: 1e9)")
         self.add_argument("--val-interval", type=int, default=1,
                             help="number of epochs between two validation checks (default: 1)")

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -198,7 +198,7 @@ class OpenSubgoal(Subgoal):
                     if obj_pos is not None and np.array_equal(obj_pos, self.fwd_pos):
                         new_subgoal = PickupSubgoal(self.bot)
                     else:
-                        new_subgoal = GoToObjSubgoal(self.bot, key_desc)
+                        new_subgoal = GoNextToSubgoal(self.bot, key_desc)
                 return new_subgoal.get_action()
 
         # If the door is already open, close it so we can open it again
@@ -237,7 +237,7 @@ class OpenSubgoal(Subgoal):
 
                     # Go to the key and pick it up
                     self.bot.stack.append(PickupSubgoal(self.bot))
-                    self.bot.stack.append(GoToObjSubgoal(self.bot, key_desc))
+                    self.bot.stack.append(GoNextToSubgoal(self.bot, key_desc))
 
                     # Drop the object being carried
                     self.bot.stack.append(DropSubgoal(self.bot))
@@ -248,7 +248,7 @@ class OpenSubgoal(Subgoal):
                     self.bot.stack.append(OpenSubgoal(self.bot, 'drop_the_key'))
                     self.bot.stack.append(GoNextToSubgoal(self.bot, tuple(self.fwd_pos)))
                     self.bot.stack.append(PickupSubgoal(self.bot))
-                    self.bot.stack.append(GoToObjSubgoal(self.bot, key_desc))
+                    self.bot.stack.append(GoNextToSubgoal(self.bot, key_desc))
 
                 return False
 
@@ -317,154 +317,6 @@ class PickupSubgoal(Subgoal):
         return True
 
 
-class GoToObjSubgoal(Subgoal):
-    def __init__(self, bot=None, datum=None, adjacent=False):
-        '''If adjacent=True, then the bot would only go two cells away from the objective (with free cell in between)'''
-        super().__init__(bot, datum)
-        self.adjacent = adjacent
-
-    def __repr__(self):
-        """Mainly for debugging purposes"""
-        representation = '('
-        representation += type(self).__name__
-        if self.datum is not None:
-            representation += ': {}'.format(self.datum)
-        if self.adjacent:
-            representation += ', adjacent'
-        representation += ')'
-
-        return representation
-
-    def get_action(self):
-        # Do we know where any one of these objects are?
-        obj_pos = self.bot.find_obj_pos(self.datum, self.adjacent)
-
-        # Go to the location of this object
-        if obj_pos:
-            # Stupid corner case: We have to go to a door, which is open, and we are currently in that position
-            if np.array_equal(obj_pos, self.pos):
-                # -> Move away from it
-                if self.fwd_cell is None:
-                    return self.actions.forward
-                if self.bot.mission.grid.get(*(self.pos + self.right_vec)) is None:
-                    return self.actions.right
-                if self.bot.mission.grid.get(*(self.pos - self.right_vec)) is None:
-                    return self.actions.left
-                # TODO: There is a corner case : you are on the position but surrounded in 4 positions - need to open a box or pickup an object to free yourself
-                # otherwise: forward, left and right are full, we assume that you can go behind
-                return self.actions.left
-
-            if self.adjacent:
-                # We need to go 2 cells away from the objecive
-                if manhattan_distance(obj_pos, self.fwd_pos) == 1:
-                    if self.fwd_cell is None:
-                        return self.subgoal_accomplished()
-                    # corner case: I just opened a door, and the target is right after the door
-                    elif self.fwd_cell.type.endswith('door') and self.fwd_cell.is_open:
-                        # add a useless subgoal that will force unblocking
-                        return GoNextToSubgoal(self.bot, self.fwd_pos + 2 * self.dir_vec).get_action()
-            else:
-                # If we are right in front of the object, then the subgoal is completed
-                # go back to the previous subgoal
-                if np.array_equal(obj_pos, self.fwd_pos):
-                    return self.subgoal_accomplished()
-
-            # Look for a non-blocker path leading to the position
-            path, _, _ = self.bot.shortest_path(
-                lambda pos, cell: pos == obj_pos,
-                try_with_blockers=True
-            )
-
-            if path:
-                # Get the action from the "GoNextTo" subgoal
-                new_subgoal = GoNextToSubgoal(self.bot, obj_pos, reason='GoToObj', adjacent=self.adjacent)
-                return new_subgoal.get_action()
-
-        # No path found -> Explore the world
-        return ExploreSubgoal(self.bot).get_action()
-
-    def take_action(self, action):
-        super().take_action(action)
-        # Do we know where any one of these objects are?
-        obj_pos = self.bot.find_obj_pos(self.datum, self.adjacent)
-
-        # Stupid corner case: We have to go to a door, which is open, and we are currently in that position
-        if np.array_equal(obj_pos, self.pos):
-            # -> Move away from it
-            if action in (self.actions.drop, self.actions.pickup, self.actions.toggle):
-                # Update the stack if we did something bad, or do nothing if the action doesn't change anything
-                self.foolish_action_while_exploring(action)
-            # Whatever other action, the stack should stay the same, and it's the new action that should be evaluated
-            # TODO: Double check what happens in this scenario with all actions
-            return True
-
-        # CASE 1: the bot has already seen the object
-        if obj_pos:
-            # CASE 1.1: we are already right in front of the object
-            # we need go back to the previous subgoal, and take it into account to handle the current action
-            if self.adjacent:
-                # We are 2 cells away from the objecive
-                if manhattan_distance(obj_pos, self.fwd_pos) == 1:
-                    if self.fwd_cell is None:
-                        self.bot.stack.pop()
-                        return False
-                    # corner case: I just opened a door, and the target is right after the door
-                    elif self.fwd_cell.type.endswith('door') and self.fwd_cell.is_open:
-                        # add a useless subgoal that will force unblocking
-                        self.bot.stack.append(GoNextToSubgoal(self.bot, self.fwd_pos + 2 * self.dir_vec))
-                        return True
-            else:
-                # If we are right in front of the object, then the subgoal is completed
-                # go back to the previous subgoal
-                if np.array_equal(obj_pos, self.fwd_pos):
-                    self.bot.stack.pop()
-                    return False
-
-
-            # CASE 1.2: The action will make us in front of the object
-            if np.array_equal(obj_pos, self.new_fwd_pos):
-                assert action in (self.actions.forward, self.actions.left, self.actions.right), "Something seems wrong"
-                # stack will be popped at next step
-                return True
-                # It is impossible that it's another action that yields this CASE 1.2
-
-            # CASE 1.3: There is a blocking object in front of us, and we aren't carrying anything
-            if self.fwd_cell is not None and not self.fwd_cell.type.endswith('door') and self.carrying is None:
-                if action == self.actions.pickup:
-                    # -> Create a GoNextTo subgoal
-                    # TODO: I am not sure this is enough. Shouldn't we drop the object somewhere?
-                    self.bot.stack.append(GoNextToSubgoal(self.bot, obj_pos))
-                    # TODO: Double check that False should be returned here
-                    return False
-
-            # CASE 1.4: All other scenarios
-            if action in (self.actions.drop, self.actions.pickup, self.actions.toggle):
-                # Update the stack if we did something bad, or do nothing if the action doesn't change anything
-                self.foolish_action_while_exploring(action)
-                return True
-
-            if action == self.actions.done or (self.fwd_cell is not None and action == self.actions.forward):
-                # Do nothing if the action doesn't change anything
-                return True
-
-            # Otherwise, the taken action (forward, left or right) has necessarily changed the agent state
-            # -> Create a GoNextTo subgoal
-            else:
-                path, _, _ = self.bot.shortest_path(
-                    lambda pos, cell: pos == obj_pos,
-                    try_with_blockers=True
-                )
-
-                if path:
-                    # New subgoal: go next to the object
-                    self.bot.stack.append(GoNextToSubgoal(self.bot, obj_pos, reason='GoToObj', adjacent=self.adjacent))
-                    return True
-
-        # CASE 2: The bot hasn't seen the object. The action will count for the new subgoal
-        self.bot.stack.append(ExploreSubgoal(self.bot))
-        return False
-
-
 class GoNextToSubgoal(Subgoal):
     def __init__(self, bot=None, datum=None, reason=None, no_reexplore=False, blocker=False, adjacent=False):
         super().__init__(bot, datum)
@@ -493,9 +345,17 @@ class GoNextToSubgoal(Subgoal):
         return representation
 
     def get_action(self):
+        if isinstance(self.datum, ObjDesc):
+            target_pos = self.bot.find_obj_pos(self.datum, self.adjacent)
+            if not target_pos:
+                # No path found -> Explore the world
+                return ExploreSubgoal(self.bot).get_action()
+        else:
+            target_pos = self.datum
+
         # CASE 1: The position we are on is the one we should go next to
         # -> Move away from it
-        if manhattan_distance(self.datum, self.pos) == (1 if self.adjacent else 0):
+        if manhattan_distance(target_pos, self.pos) == (1 if self.adjacent else 0):
             if self.fwd_cell is None:
                 return self.actions.forward
             if self.bot.mission.grid.get(*(self.pos + self.right_vec)) is None:
@@ -508,16 +368,16 @@ class GoNextToSubgoal(Subgoal):
 
         # CASE 2: we are facing the target cell, subgoal completed
         if self.adjacent:
-            if manhattan_distance(self.datum, self.fwd_pos) == 1 and self.fwd_cell is None:
+            if manhattan_distance(target_pos, self.fwd_pos) == 1 and self.fwd_cell is None:
                 return self.subgoal_accomplished()
         else:
-            if np.array_equal(self.datum, self.fwd_pos):
+            if np.array_equal(target_pos, self.fwd_pos):
                 return self.subgoal_accomplished()
 
         # CASE 3: we are still far from the target
         # Try to find a non-blocker path
         path, _, _ = self.bot.shortest_path(
-            lambda pos, cell: np.array_equal(pos, self.datum)
+            lambda pos, cell: np.array_equal(pos, target_pos)
         )
 
         # CASE 3.1: No non-blocker path found, and reexploration is allowed
@@ -539,7 +399,7 @@ class GoNextToSubgoal(Subgoal):
         # -> Look for blocker paths
         if not path:
             path, _, _ = self.bot.shortest_path(
-                lambda pos, cell: np.array_equal(pos, self.datum),
+                lambda pos, cell: np.array_equal(pos, target_pos),
                 try_with_blockers=True
             )
 
@@ -601,9 +461,18 @@ class GoNextToSubgoal(Subgoal):
     def take_action(self, action):
         super().take_action(action)
 
+        if isinstance(self.datum, ObjDesc):
+            target_pos = self.bot.find_obj_pos(self.datum, self.adjacent)
+            if not target_pos:
+                # CASE 2: The bot hasn't seen the object. The action will count for the new subgoal
+                self.bot.stack.append(ExploreSubgoal(self.bot))
+                return False
+        else:
+            target_pos = self.datum
+
         # CASE 1: The position we are on is the one we should go next to
         # -> Move away from it
-        if manhattan_distance(self.datum, self.pos) == (1 if self.adjacent else 0):
+        if manhattan_distance(target_pos, self.pos) == (1 if self.adjacent else 0):
             if action in (self.actions.drop, self.actions.pickup, self.actions.toggle):
                 # Update the stack if we did something bad, or do nothing if the action doesn't change anything
                 self.foolish_action_while_exploring(action)
@@ -613,7 +482,7 @@ class GoNextToSubgoal(Subgoal):
 
         # CASE 2: we are facing the target cell, subgoal completed
         if self.adjacent:
-            if manhattan_distance(self.datum, self.fwd_pos) == 1:
+            if manhattan_distance(target_pos, self.fwd_pos) == 1:
                 if self.fwd_cell is None:
                     self.bot.stack.pop()
                     return False
@@ -623,15 +492,15 @@ class GoNextToSubgoal(Subgoal):
                     self.bot.stack.append(GoNextToSubgoal(self.bot, self.fwd_pos + 2 * self.dir_vec))
                     return True
         else:
-            if np.array_equal(self.datum, self.fwd_pos):
+            if np.array_equal(target_pos, self.fwd_pos):
                 self.bot.stack.pop()
                 return False
 
-        assert tuple(self.new_pos) != tuple(self.datum), "Doesn't make sense with CASE 2"
+        assert tuple(self.new_pos) != tuple(target_pos), "Doesn't make sense with CASE 2"
 
         # CASE 3: the action taken would lead us to face the target cell
         # -> Don't do anything. The stack will be popped at next step anyway
-        if np.array_equal(self.datum, self.new_fwd_pos):
+        if np.array_equal(target_pos, self.new_fwd_pos):
             assert action in (self.actions.forward, self.actions.left, self.actions.right), "Doesn't make sense"
             return True
 
@@ -647,7 +516,7 @@ class GoNextToSubgoal(Subgoal):
         # CASE 5: otherwise
         # Try to find a path
         path, _, _ = self.bot.shortest_path(
-            lambda pos, cell: np.array_equal(pos, self.datum),
+            lambda pos, cell: np.array_equal(pos, target_pos),
             try_with_blockers=True
         )
 
@@ -702,7 +571,7 @@ class GoNextToSubgoal(Subgoal):
             if not self.blocker:
                 self.bot.stack.pop()
             else:
-                if self.bot.vis_mask[self.datum]:
+                if self.bot.vis_mask[target_pos]:
                     self.bot.stack.pop()
         return True
 
@@ -1070,12 +939,12 @@ class Bot:
         """
 
         if isinstance(instr, GoToInstr):
-            self.stack.append(GoToObjSubgoal(self, instr.desc))
+            self.stack.append(GoNextToSubgoal(self, instr.desc))
             return
 
         if isinstance(instr, OpenInstr):
             self.stack.append(OpenSubgoal(self))
-            self.stack.append(GoToObjSubgoal(self, instr.desc))
+            self.stack.append(GoNextToSubgoal(self, instr.desc))
             return
 
         if isinstance(instr, PickupInstr):
@@ -1083,14 +952,14 @@ class Bot:
             # that we may carry other objects
             self.stack.append(DropSubgoal(self))
             self.stack.append(PickupSubgoal(self))
-            self.stack.append(GoToObjSubgoal(self, instr.desc))
+            self.stack.append(GoNextToSubgoal(self, instr.desc))
             return
 
         if isinstance(instr, PutNextInstr):
             self.stack.append(DropSubgoal(self))
-            self.stack.append(GoToObjSubgoal(self, instr.desc_fixed, adjacent=True))
+            self.stack.append(GoNextToSubgoal(self, instr.desc_fixed, adjacent=True))
             self.stack.append(PickupSubgoal(self))
-            self.stack.append(GoToObjSubgoal(self, instr.desc_move))
+            self.stack.append(GoNextToSubgoal(self, instr.desc_move))
             return
 
         if isinstance(instr, BeforeInstr) or isinstance(instr, AndInstr):

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -351,7 +351,7 @@ class GoNextToSubgoal(Subgoal):
                 # No path found -> Explore the world
                 return ExploreSubgoal(self.bot).get_action()
         else:
-            target_pos = self.datum
+            target_pos = tuple(self.datum)
 
         # CASE 1: The position we are on is the one we should go next to
         # -> Move away from it
@@ -377,7 +377,7 @@ class GoNextToSubgoal(Subgoal):
         # CASE 3: we are still far from the target
         # Try to find a non-blocker path
         path, _, _ = self.bot.shortest_path(
-            lambda pos, cell: np.array_equal(pos, target_pos)
+            lambda pos, cell: pos == target_pos,
         )
 
         # CASE 3.1: No non-blocker path found, and reexploration is allowed
@@ -399,7 +399,7 @@ class GoNextToSubgoal(Subgoal):
         # -> Look for blocker paths
         if not path:
             path, _, _ = self.bot.shortest_path(
-                lambda pos, cell: np.array_equal(pos, target_pos),
+                lambda pos, cell: pos == target_pos,
                 try_with_blockers=True
             )
 
@@ -468,7 +468,7 @@ class GoNextToSubgoal(Subgoal):
                 self.bot.stack.append(ExploreSubgoal(self.bot))
                 return False
         else:
-            target_pos = self.datum
+            target_pos = tuple(self.datum)
 
         # CASE 1: The position we are on is the one we should go next to
         # -> Move away from it
@@ -516,7 +516,7 @@ class GoNextToSubgoal(Subgoal):
         # CASE 5: otherwise
         # Try to find a path
         path, _, _ = self.bot.shortest_path(
-            lambda pos, cell: np.array_equal(pos, target_pos),
+            lambda pos, cell: pos == target_pos,
             try_with_blockers=True
         )
 
@@ -699,6 +699,7 @@ class Bot:
         self.process_instr(mission.instrs)
 
         self.bfs_counter = 0
+        self.bfs_step_counter = 0
 
     def find_obj_pos(self, obj_desc, adjacent=False):
         """
@@ -791,6 +792,8 @@ class Bot:
         going straight over turning.
 
         """
+        self.bfs_counter += 1
+
         queue = [(state, None) for state in initial_states]
         grid = self.mission.grid
         previous_pos = dict()
@@ -803,7 +806,7 @@ class Bot:
             if (i, j) in previous_pos:
                 continue
 
-            self.bfs_counter += 1
+            self.bfs_step_counter += 1
 
             cell = grid.get(i, j)
             previous_pos[(i, j)] = prev_pos

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -325,10 +325,10 @@ class GoNextToSubgoal(Subgoal):
     datum : (int, int) or ObjDescr
         Where the bot should go. Can be either a grid position, or an object description. If
         `datum` is an object description it is resolved anew at each step, meaning that the bot
-        can change its mind and go another object that matches the same description.
+        can change its mind and go to another object that matches the same description.
     adjacent : bool
-        When True, the bot aims to face an empty cell that is adjacent to the target cell or object.
-        When False (default), the bot aims to face the target cell or object.
+        When `True`, the bot aims to face an empty cell that is adjacent to the target cell or object.
+        When `False` (default), the bot aims to face the target cell or object.
     no_reexplore : bool
         Suppresses the heuristics of additional exploration within the current room even
         when a blocker path is already found.

--- a/scripts/eval_bot.py
+++ b/scripts/eval_bot.py
@@ -98,6 +98,8 @@ for level_name in level_list:
     num_success = 0
     total_reward = 0
     total_steps = []
+    total_bfs = 0
+    total_episode_steps = 0
     total_bfs_steps = 0
 
     for run_no in range(options.num_runs):
@@ -143,7 +145,9 @@ for level_name in level_list:
                 episode_steps += 1
 
                 if done:
-                    total_bfs_steps += expert.bfs_counter
+                    total_episode_steps += episode_steps
+                    total_bfs_steps += expert.bfs_step_counter
+                    total_bfs += expert.bfs_counter
                     if reward > 0:
                         num_success += 1
                         total_steps.append(episode_steps)
@@ -172,5 +176,6 @@ total_time = end_time - start_time
 print('total time: %.1fs' % total_time)
 if not all_good:
     raise Exception("some tests failed")
-print(total_bfs_steps)
-
+print('total episode_steps:', total_episode_steps)
+print('total bfs:', total_bfs)
+print('total bfs steps:', total_bfs_steps)

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -24,7 +24,7 @@ parser.add_argument("--demos", default=None,
                     help="name of the demos file (REQUIRED or --demos-origin or --model REQUIRED)")
 parser.add_argument("--episodes", type=int, default=1000,
                     help="number of episodes of evaluation (default: 1000)")
-parser.add_argument("--seed", type=int, default=1e9,
+parser.add_argument("--seed", type=int, default=int(1e9),
                     help="random seed")
 parser.add_argument("--argmax", action="store_true", default=False,
                     help="action with highest probability is selected for model agent")

--- a/scripts/make_agent_demos.py
+++ b/scripts/make_agent_demos.py
@@ -162,7 +162,7 @@ def generate_demos_cluster():
     for i in range(args.jobs):
         cmd_i = list(map(str,
             command
-              + ['--seed', args.seed + i]
+              + ['--seed', args.seed + i * demos_per_job]
               + ['--demos', job_demo_names[i]]
               + ['--episodes', demos_per_job]
               + ['--jobs', 0]

--- a/scripts/make_agent_demos.py
+++ b/scripts/make_agent_demos.py
@@ -113,7 +113,7 @@ def generate_demos(n_episodes, valid, seed, shift=0):
                 break
             if reward == 0:
                 if args.on_exception == 'crash':
-                    raise Exception("mission failed")
+                    raise Exception("mission failed, the seed is {}".format(seed + len(demos)))
                 logger.info("mission failed")
         except Exception:
             if args.on_exception == 'crash':

--- a/scripts/train_intelligent_expert.py
+++ b/scripts/train_intelligent_expert.py
@@ -86,7 +86,6 @@ def evaluate_agent(il_learn, eval_seed, num_eval_demos, return_obss_actions=Fals
         il_learn.args.env,
         episodes=num_eval_demos,
         seed=eval_seed,
-        seed_shift=0,
         return_obss_actions=return_obss_actions
     )
     agent.model.train()


### PR DESCRIPTION
This was surprisingly easy. I just added the logic for looking for the object to `GoToObj`, and it worked immediately. I tested on 200 levels:

**Master:**
```
(babyai) ╭─dzmitry@dzmitry-ThinkPad-X1-Carbon-5th ~/Dist/baby-ai-game  ‹dima-byebye-gotoobj*› 
╰─$ python scripts/eval_bot.py  --num_runs=200 --level=BossLevel
       BossLevel: 100.0%, r=0.945, s=86.47
total time: 61.2s
4387296
```

**PR**
```
(babyai) ╭─dzmitry@dzmitry-ThinkPad-X1-Carbon-5th ~/Dist/baby-ai-game  ‹dima-byebye-gotoobj*› 
╰─$ python scripts/eval_bot.py  --num_runs=200 --level=BossLevel
       BossLevel: 100.0%, r=0.945, s=86.39
total time: 64.6s
5193343
```

In terms of wall time, the bot becomes somewhat slower, but I am hopeful to mitigate this by adding a cache to `shortest_path`, because that function is often repeatedly called with the same arguments.