### PR TITLE
go straight for the key 

### DIFF
--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -264,8 +264,9 @@ class GoNextToSubgoal(Subgoal):
 
     Parameters:
     ----------
-    datum : (int, int) tuple or `ObjDesc`
-        The position or the object to which we are going:
+    datum : (int, int) tuple or `ObjDesc` or object reference
+        The position or the decription of the object or
+        the object to which we are going.
     reason : str
         One of the following:
         - `None`: go the position (object) and face it
@@ -291,6 +292,9 @@ class GoNextToSubgoal(Subgoal):
                 # No path found -> Explore the world
                 self.bot.stack.append(ExploreSubgoal(self.bot))
                 return
+        elif isinstance(self.datum, WorldObj):
+            target_obj = self.datum
+            target_pos = target_obj.cur_pos
         else:
             target_pos = tuple(self.datum)
 
@@ -475,9 +479,11 @@ class ExploreSubgoal(Subgoal):
 
         # Open the door
         if door_pos:
+            door_obj = self.bot.mission.grid.get(*door_pos)
             self.bot.stack.pop()
-            self.bot.stack.append(OpenSubgoal(self.bot))
-            self.bot.stack.append(GoNextToSubgoal(self.bot, door_pos))
+            self.bot.stack.append(OpenSubgoal(
+                self.bot, reason='Unlock' if door_obj.is_locked else None))
+            self.bot.stack.append(GoNextToSubgoal(self.bot, door_obj, reason='Open'))
             return
 
         assert False, "0nothing left to explore"

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -157,9 +157,13 @@ class OpenSubgoal(Subgoal):
     Parameters:
     ----------
     reason : str
-        Can be either `None` or `"Unlock"`. If the reason is `"Unlock"`,
+        `None`, `"Unlock"`, or `"UnlockAndKeepKey"`. If the reason is `"Unlock"`,
         the agent will plan dropping the key somewhere after it opens the door
-        (see `replan_after_action`).
+        (see `replan_after_action`). When the agent faces the door, and the
+        reason is `None`, this subgoals replaces itself with a similar one,
+        but with with the reason `"Unlock"`. `reason="UnlockAndKeepKey` means
+        that the agent should not schedule the dropping of the key
+        when it faces a locked door, and should instead keep the key.
 
     """
 
@@ -189,7 +193,7 @@ class OpenSubgoal(Subgoal):
                 self.bot.stack.append(GoNextToSubgoal(self.bot, drop_pos_cur))
 
                 # Go back to the door and open it
-                self.bot.stack.append(OpenSubgoal(self.bot, reason='Unlock'))
+                self.bot.stack.append(OpenSubgoal(self.bot))
                 self.bot.stack.append(GoNextToSubgoal(self.bot, tuple(self.fwd_pos)))
 
                 # Go to the key and pick it up
@@ -200,10 +204,16 @@ class OpenSubgoal(Subgoal):
                 self.bot.stack.append(DropSubgoal(self.bot))
                 self.bot.stack.append(GoNextToSubgoal(self.bot, drop_pos_cur))
             else:
+                # This branch is will be used very rarely, given that
+                # GoNextToSubGoal(..., reason='Open') should plan
+                # going to the key before we get to stand right in front of a door.
+                # But the agent can be spawned right in front of a open door,
+                # for which we case we do need this code.
+
                 self.bot.stack.pop()
 
                 # Go back to the door and open it
-                self.bot.stack.append(OpenSubgoal(self.bot, reason='Unlock'))
+                self.bot.stack.append(OpenSubgoal(self.bot))
                 self.bot.stack.append(GoNextToSubgoal(self.bot, tuple(self.fwd_pos)))
 
                 # Go to the key and pick it up

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -313,6 +313,9 @@ class GoNextToSubgoal(Subgoal):
             key_desc = ObjDesc('key', target_obj.color)
             key_desc.find_matching_objs(self.bot.mission)
             if not self.carrying:
+                # No we need to commit to going to this particular door
+                self.bot.stack.pop()
+                self.bot.stack.append(GoNextToSubgoal(self.bot, target_obj, reason='Open'))
                 self.bot.stack.append(PickupSubgoal(self.bot))
                 self.bot.stack.append(GoNextToSubgoal(self.bot, key_desc))
                 return

--- a/babyai/bot.py
+++ b/babyai/bot.py
@@ -298,6 +298,11 @@ class GoNextToSubgoal(Subgoal):
         else:
             target_pos = tuple(self.datum)
 
+        # Suppore we are walking towards the door that we would like to open,
+        # it is locked, and we don't have the key. What do we do? If we are carrying
+        # something, it makes to just continue, as we still need to bring this object
+        # close to the door. If we are not carrying anything though, then it makes
+        # sense to change the plan and go straight for the required key.
         if (self.reason == 'Open'
                 and target_obj and target_obj.type == 'door' and target_obj.is_locked):
             key_desc = ObjDesc('key', target_obj.color)


### PR DESCRIPTION
Fixes #29 .

The main change here is adding `reason="Open"` to `GoNextToSubgoal`. When working on a subgoal with `reason="Open"` the agent can interrupt going to the door and go to the respective key instead. The agent commits in such case to go the specific locked door, even if it later finds a suitable open door. Such a commitment is necessary in order to remember to drop the key. 

After the above change, an issue arose whereby it was not clear when the agent should drop the key after opening the door and when it shouldn't. I figured that the agent should always drop the key unless it had already had the key when it decided to walk to the door. `reason="UnlockAndKeepKey"` was introduced to handle this case. 

The bot gained some speed (see below). 1M demo test is yet to be launched.

```
(babyai) ╭─dzmitry@dzmitry-ThinkPad-X1-Carbon-5th ~/Dist/baby-ai-game  ‹dima-faster-unlock*› 
╰─$ python3 -m scripts.eval_bot --level GoToImpUnlock --num_runs 200                          
   GoToImpUnlock: 100.0%, r=0.830, s=108.94
total time: 41.5s
total episode_steps: 21787
total bfs: 35436
total bfs steps: 3115704
(babyai) ╭─dzmitry@dzmitry-ThinkPad-X1-Carbon-5th ~/Dist/baby-ai-game  ‹master› 
╰─$ python3 -m scripts.eval_bot --level GoToImpUnlock --num_runs 200
   GoToImpUnlock: 100.0%, r=0.817, s=117.06
total time: 37.9s
total episode_steps: 23413
total bfs: 36966
total bfs steps: 3387158
```
