### PR TITLE
better behaviour for the case when the bot fails a mission

### DIFF
--- a/scripts/make_agent_demos.py
+++ b/scripts/make_agent_demos.py
@@ -80,11 +80,11 @@ def generate_demos(n_episodes, valid, seed, shift=0):
 
     checkpoint_time = time.time()
 
-    while True:
+    for i in range(n_episodes):
         # Run the expert for one episode
 
         done = False
-        env.seed(seed + len(demos))
+        env.seed(seed + i)
         obs = env.reset()
         agent.on_reset()
 
@@ -109,8 +109,6 @@ def generate_demos(n_episodes, valid, seed, shift=0):
             if reward > 0 and (args.filter_steps == 0 or len(images) <= args.filter_steps):
                 demos.append((mission, blosc.pack_array(np.array(images)), directions, actions))
 
-            if len(demos) >= n_episodes:
-                break
             if reward == 0:
                 if args.on_exception == 'crash':
                     raise Exception("mission failed, the seed is {}".format(seed + len(demos)))
@@ -137,7 +135,6 @@ def generate_demos(n_episodes, valid, seed, shift=0):
             logger.info("Demos saved")
             # print statistics for the last 100 demonstrations
             print_demo_lengths(demos[-100:])
-
 
 
     # Save demonstrations


### PR DESCRIPTION
So... the bot still occasionally fails. 1 time out of 1000000, and for a good reason: when the agent is really badly blocked from the very beginning:
![image](https://user-images.githubusercontent.com/654434/52127355-de6bb680-25ff-11e9-8a2d-4fbb3f8c3d52.png)


I think it's fine, and want to continue generating demos. This PR tweaks `make_agent_demos.py` a bit to just skip the seed on which agent fails and proceed to other missions. This way we'll have 999999 demos instead of 1000000 for some levels, which I think is bearable. 